### PR TITLE
docs: mark action as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # markdownlint action
 
+> [!CAUTION]
+> This action is deprecated. Use [DavidAnson/markdownlint-cli2-action](https://github.com/DavidAnson/markdownlint-cli2-action)
+> or [super-linter](https://github.com/super-linter/super-linter) instead.
+
 This action lints your Markdown files with [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli).
 
 ## Usage


### PR DESCRIPTION
There are other maintained versions of this action out there. Use those instead